### PR TITLE
feat(align): support for runtime alignment assertions

### DIFF
--- a/src/tanuki/__init__.py
+++ b/src/tanuki/__init__.py
@@ -169,14 +169,14 @@ def align(test_func):
                 pass
             # Call as a standalone function
             _namespace = namespace
-            func = _namespace.get(func_name)
+            #func = _namespace.get(func_name)
 
             register(func_name, *args, **kwargs, positive=__align_direction, expected_output=__expected_output, instance=None)
 
-            if func:
-                return func(*args, **kwargs)
-            else:
-                raise NameError(f"Function '{func_name}' not found.")
+            #if func:
+            #    return func(*args, **kwargs)
+            #else:
+            #    raise NameError(f"Function '{func_name}' not found.")
 
         return dynamic_call
 
@@ -219,9 +219,9 @@ def align(test_func):
             modified_tree = ast.fix_missing_locations(modified_tree)
 
             # Dump the modified AST to string for debug purposes
-            #dump = ast.dump(modified_tree, indent=2, include_attributes=True)
+            dump = ast.dump(modified_tree, indent=2, include_attributes=True)
             # Get the modified source code for debug purposes
-            #source_code = astor.to_source(modified_tree)
+            source_code = astor.to_source(modified_tree)
 
             # Compile the modified AST
             try:
@@ -236,7 +236,6 @@ def align(test_func):
                 'dynamic_call': make_dynamic_call_with_namespace(parent_module),
                 **parent_module
             }
-
 
             with DisableRuntimeAlign():
                 exec(compiled_code, namespace)

--- a/src/tanuki/__init__.py
+++ b/src/tanuki/__init__.py
@@ -180,7 +180,6 @@ def align(test_func):
 
         return dynamic_call
 
-
     @wraps(test_func)
     def wrapper(*args, **kwargs):
         # If the global variable is set, run the function without aligning. This is to prevent infinite recursion.

--- a/src/tanuki/__init__.py
+++ b/src/tanuki/__init__.py
@@ -1,4 +1,5 @@
 import ast
+import importlib
 import inspect
 import json
 import logging
@@ -9,9 +10,13 @@ from functools import wraps
 from typing import Optional, Union, Any
 from unittest.mock import patch as mock_patch
 
+import astor as astor
 import requests
+
+import tanuki
 from tanuki.models.api_manager import APIManager
-from tanuki.assertion_visitor import AssertionVisitor
+from tanuki.runtime_assertion_visitor import RuntimeAssertionVisitor
+from tanuki.static_assertion_visitor import StaticAssertionVisitor
 from tanuki.function_modeler import FunctionModeler
 from tanuki.language_models.embedding_model_manager import EmbeddingModelManager
 from tanuki.language_models.language_model_manager import LanguageModelManager
@@ -52,6 +57,12 @@ def _log_align(self, func_hash, *args, **kws):
         except IOError as e:
             self.error(f"Failed to write to log file: {e}")
 
+class DisableRuntimeAlign:
+    def __enter__(self):
+        globals()[DISABLE_RUNTIME_ALIGN] = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        globals()[DISABLE_RUNTIME_ALIGN] = False
 
 # Set up logging with custom logger
 def logger_factory(name):
@@ -78,6 +89,8 @@ language_modeler = LanguageModelManager(function_modeler, api_provider=api_provi
 embedding_modeler = EmbeddingModelManager(function_modeler, api_provider=api_provider)
 telemetry_enabled: bool = True
 
+DISABLE_RUNTIME_ALIGN = '__disable_runtime_align__'
+__disable_runtime_align__ = False
 
 @staticmethod
 def _load_alignments(func_hash: str):
@@ -96,8 +109,151 @@ def _anonymous_usage(*args, **kwargs):
     except:
         pass
 
+
 @staticmethod
 def align(test_func):
+    """
+    Decorator to align a function.
+
+    This version modifies the AST to replace assert statements with runtime
+    register calls, then compiles and executes the modified function.
+    """
+
+    def register(func_name, *args, expected_output, positive=False, instance=None, **kwargs):
+        if instance:
+            function_names_to_patch = Register.function_names_to_patch(instance)  # , type=FunctionType.SYMBOLIC)
+            functions_descriptions = [Register.load_function_description_from_name(instance, func_name)
+                                      for func_name in function_names_to_patch]
+        else:
+            function_names_to_patch = Register.function_names_to_patch()  # type=FunctionType.SYMBOLIC)
+            functions_descriptions = [Register.load_function_description_from_name(func_name)
+                                      for func_name in function_names_to_patch]
+
+        for desc, fn_name in zip(functions_descriptions, function_names_to_patch):
+            if fn_name == func_name:
+                hashed_description = desc.__hash__()
+                if desc.type == FunctionType.EMBEDDABLE:
+                    if positive:
+                        # Implement logic for handling positive (equality) assertions
+                        positive_pairs = []
+                        logger.log(ALIGN_LEVEL_NUM, f"Registering positive embedding pairs for {fn_name}: {positive_pairs}")
+                        function_modeler.save_embeddable_align_statements(hashed_description, args, kwargs, positive_pairs=positive_pairs)
+                    else:
+                        negative_pairs = []
+                        logger.info(f"Registering negative embedding pairs for {fn_name}: {negative_pairs}")
+                        function_modeler.save_embeddable_align_statements(hashed_description, args, kwargs, negative_pairs=negative_pairs)
+                elif desc.type == FunctionType.SYMBOLIC:
+                    if positive:
+                        logger.info(f"Registering symbolic align for {fn_name}{args}{dict(**kwargs)}: {expected_output}")
+                        print(f"Registering symbolic align for {fn_name}{args}{dict(**kwargs)}: {expected_output}")
+                        function_modeler.save_symbolic_align_statements(hashed_description, args, kwargs, expected_output)
+                    else:
+                        raise NotImplementedError("Negative assertions for symbolic functions are not supported yet because most LLM providers dont offer a negative finetuning API")
+                break
+
+    def make_dynamic_call_with_namespace(namespace):
+        def dynamic_call(func_name, *args, __expected_output: any = None, __align_direction: bool = True, **kwargs):
+            if 'self' in globals():
+                # If 'self' is defined globally (unlikely in normal use),
+                # this will throw an error as this approach relies on runtime context
+                raise NameError("'self' found in globals; ambiguous context.")
+            try:
+                # Attempt to call as a method on an instance
+                instance = kwargs.pop('instance', None)
+                if instance is not None:
+                    method = getattr(instance, func_name)
+                    register(func_name, *args, **kwargs, positive=__align_direction, expected_output=__expected_output, instance=instance)
+                    return method(*args, **kwargs)
+            except AttributeError:
+                # 'instance' does not have the method; fall back to a function call
+                pass
+            # Call as a standalone function
+            _namespace = namespace
+            func = _namespace.get(func_name)
+
+            register(func_name, *args, **kwargs, positive=__align_direction, expected_output=__expected_output, instance=None)
+
+            if func:
+                return func(*args, **kwargs)
+            else:
+                raise NameError(f"Function '{func_name}' not found.")
+
+        return dynamic_call
+
+
+    @wraps(test_func)
+    def wrapper(*args, **kwargs):
+        # If the global variable is set, run the function without aligning. This is to prevent infinite recursion.
+        _globals = test_func.__globals__
+
+        if _globals.get(DISABLE_RUNTIME_ALIGN, False):
+            #_globals = globals()
+            _locals = locals().copy()
+            return test_func(*args, **kwargs)
+        else:
+            source = textwrap.dedent(inspect.getsource(test_func))
+            # Extract imports from the file where test_func is defined
+            #imported_modules = extract_file_imports(test_func)
+
+            tree = ast.parse(source)
+            _locals = locals().copy()
+
+            if args:
+                instance = args[0]
+                args = args[1:]
+            else:
+                instance = None
+
+            # Registered functions to patch
+            patch_symbolic_funcs = Register.functions_to_patch(type=FunctionType.SYMBOLIC)
+            patch_embeddable_funcs = Register.functions_to_patch(type=FunctionType.EMBEDDABLE)
+
+            # Initialize the visitor with function_modeler
+            visitor = RuntimeAssertionVisitor(#function_modeler=function_modeler,
+                                              instance=instance,
+                                              patch_symbolic_funcs=patch_symbolic_funcs,
+                                              patch_embeddable_funcs=patch_embeddable_funcs)
+            tree = ast.parse(source)
+            modified_tree = visitor.visit(tree)
+
+            modified_tree = ast.fix_missing_locations(modified_tree)
+
+            # Dump the modified AST to string for debug purposes
+            #dump = ast.dump(modified_tree, indent=2, include_attributes=True)
+            # Get the modified source code for debug purposes
+            #source_code = astor.to_source(modified_tree)
+
+            # Compile the modified AST
+            try:
+                compiled_code = compile(modified_tree, filename="<ast>", mode="exec")
+            except Exception as e:
+                raise SyntaxError(f"Syntax error in modified code: {e}")
+
+            # Execute the compiled code in a new namespace to avoid overwriting
+            parent_module = inspect.getmodule(test_func).__dict__
+            namespace = {
+                DISABLE_RUNTIME_ALIGN: True,
+                'dynamic_call': make_dynamic_call_with_namespace(parent_module),
+                **parent_module
+            }
+
+
+            with DisableRuntimeAlign():
+                exec(compiled_code, namespace)
+
+            # Retrieve the modified function from the namespace and call it
+            modified_func_name = test_func.__name__
+            modified_func = namespace.get(modified_func_name)
+
+            if modified_func:
+                return modified_func(*args, **kwargs)
+            else:
+                raise RuntimeError("Modified function not found after AST modification.")
+    return wrapper
+
+
+@staticmethod
+def align_static(test_func):
     """
     Decorator to align a function.
 
@@ -119,9 +275,9 @@ def align(test_func):
 
         patch_symbolic_funcs = Register.functions_to_patch(type=FunctionType.SYMBOLIC)
         patch_embeddable_funcs = Register.functions_to_patch(type=FunctionType.EMBEDDABLE)
-        visitor = AssertionVisitor(_locals,
-                                   patch_symbolic_funcs=patch_symbolic_funcs,
-                                   patch_embeddable_funcs=patch_embeddable_funcs)
+        visitor = StaticAssertionVisitor(_locals,
+                                         patch_symbolic_funcs=patch_symbolic_funcs,
+                                         patch_embeddable_funcs=patch_embeddable_funcs)
         visitor.visit(tree)
 
         # Get the mocked behaviours from analyzing the AST of the aligned function
@@ -148,6 +304,7 @@ def align(test_func):
                 attributes['keys'] = list(result.keys())
 
             return attributes
+
 
         def create_mock_func(instance: Optional,
                              func_name: str,

--- a/src/tanuki/_test_ast_parsing.py
+++ b/src/tanuki/_test_ast_parsing.py
@@ -1,0 +1,25 @@
+import ast
+
+# Manually create a simple AST for a function with a single pass statement
+simple_tree = ast.Module(body=[
+    ast.FunctionDef(
+        name='dummy_function',
+        args=ast.arguments(
+            posonlyargs=[], args=[], vararg=None,
+            kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]
+        ),
+        body=[ast.Pass()],
+        decorator_list=[]
+    )
+], type_ignores=[])
+
+# Apply fix_missing_locations
+ast.fix_missing_locations(simple_tree)
+
+# Attempt to compile
+try:
+    compiled = compile(simple_tree, filename="<ast>", mode="exec")
+    exec(compiled)
+    print("Compilation and execution successful.")
+except Exception as e:
+    print(f"Error during compilation or execution: {e}")

--- a/src/tanuki/function_modeler.py
+++ b/src/tanuki/function_modeler.py
@@ -158,6 +158,7 @@ class FunctionModeler(object):
                 self.embeddable_align_buffer[function_hash] = bytearray()
             self.embeddable_align_buffer[function_hash].extend(str(example.__dict__).encode('utf-8') + b'\r\n')
 
+
     def save_symbolic_align_statements(self, function_hash, args, kwargs, output):
         """
         Save the align statements and add to the align buffer

--- a/src/tanuki/runtime_assertion_visitor.py
+++ b/src/tanuki/runtime_assertion_visitor.py
@@ -99,7 +99,8 @@ class RuntimeAssertionVisitor(ast.NodeTransformer):
         elif isinstance(node, ast.Constant):
             return node
         else:
-            raise NotImplementedError(f"Unsupported argument type: {type(node)}")
+            return node
+            #raise NotImplementedError(f"Unsupported argument type: {type(node)}")
 
     def create_register_call(self, assert_node, _align_direction: bool = True):
         # Extract the function call and the expected output from the assert statement

--- a/src/tanuki/runtime_assertion_visitor.py
+++ b/src/tanuki/runtime_assertion_visitor.py
@@ -1,0 +1,147 @@
+import ast
+import sys
+from typing import Optional, Dict, Callable
+
+from tanuki.models.function_type import FunctionType
+from tanuki.register import Register
+
+
+class Or(list):
+    pass
+
+
+class RuntimeAssertionVisitor(ast.NodeTransformer):
+    def __init__(self,
+                 instance: Optional[object] = None,
+                 patch_symbolic_funcs: Dict[str, Callable] = {},
+                 patch_embeddable_funcs: Dict[str, Callable] = {}):
+
+        self.instance = instance
+        self.patch_symbolic_names = list(patch_symbolic_funcs.keys())  # names of symbolic functions to patch
+        self.patch_symbolic_funcs = patch_symbolic_funcs  # symbolic functions to patch
+        self.patch_embeddable_names = list(patch_embeddable_funcs.keys())  # names of embeddable functions to patch
+        self.patch_embeddable_funcs = patch_embeddable_funcs  # embeddable functions to patch
+
+    def extract_func_name(self, call_node):
+        """
+        Extracts the function name from a call node.
+
+        Args:
+            call_node (ast.Call): The AST node representing a function call.
+
+        Returns:
+            str: The extracted function name.
+        """
+        if isinstance(call_node.func, ast.Name):
+            # Direct function call, e.g., func_name(...)
+            return call_node.func.id
+        elif isinstance(call_node.func, ast.Attribute):
+            # Method or namespaced function call, e.g., module.func_name(...)
+            # For simplicity, this returns just the attribute name (func_name) but could be
+            # extended to include the full path (module.func_name) if needed.
+            return call_node.func.attr
+        else:
+            # If the function call doesn't match expected patterns (Name or Attribute),
+            # raise an error or handle it according to your needs.
+            raise NotImplementedError(f"Unsupported function call type: {type(call_node.func)}")
+
+    def visit_Assert(self, node):
+        # Check if either side of the assert involves a patched function
+        left_func_name = self.extract_func_name(node.test.left) if isinstance(node.test.left, ast.Call) else None
+        right_func_name = self.extract_func_name(node.test.comparators[0]) if isinstance(node.test.comparators[0],
+                                                                                         ast.Call) else None
+
+        left_is_patchable = self.is_function_patchable(left_func_name, self.instance) if left_func_name else False
+        right_is_patchable = self.is_function_patchable(right_func_name,
+                                                        self.instance) if right_func_name else False
+
+        # Proceed only if at least one side is a patched function call
+        if left_is_patchable or right_is_patchable:
+            if isinstance(node.test.ops[0], ast.Eq):
+                return self.create_register_call(node, _align_direction=True)
+            elif isinstance(node.test.ops[0], ast.NotEq):
+                return self.create_register_call(node, _align_direction=False)
+            else:
+                return node  # Non-supported comparison operator
+        else:
+            return node  # Neither side involves a patched function
+
+    def visit_FunctionDef(self, node):
+        # Remove the decorator if it matches decorator_name
+        node.decorator_list = [dec for dec in node.decorator_list
+                               if not (isinstance(dec, ast.Name) and dec.id == self.decorator_name)]
+        self.generic_visit(node)
+        return node
+
+    def is_function_patchable(self, func_name, instance=None):
+        """
+        Checks if a function is listed as a patchable function in the Register.
+        """
+        if instance:
+            function_names_to_patch = Register.function_names_to_patch(instance)
+        else:
+            function_names_to_patch = Register.function_names_to_patch()
+
+        return func_name in function_names_to_patch
+
+    def transform_arg(self, node):
+        """
+        Transforms an AST node into a form suitable for inclusion in the args list of an ast.Call node.
+        """
+        if isinstance(node, ast.Str):
+            return node  # Strings can be directly included
+        elif isinstance(node, ast.Num):
+            return node  # Numbers can be directly included
+        elif isinstance(node, ast.Name):
+            return ast.Name(id=node.id, ctx=ast.Load())  # Variables are included by name
+        elif isinstance(node, (ast.List, ast.Dict, ast.Tuple)):
+            return node  # Directly include compound types
+        elif isinstance(node, ast.Constant):
+            return node
+        else:
+            raise NotImplementedError(f"Unsupported argument type: {type(node)}")
+
+    def create_register_call(self, assert_node, _align_direction: bool = True):
+        # Extract the function call and the expected output from the assert statement
+        func_call = assert_node.test.left
+        expected_output = assert_node.test.comparators[0]
+
+        # Assuming the function call is directly a call to a function (not nested in other expressions)
+        if not isinstance(func_call, ast.Call):
+            raise ValueError("Assertion left side is not a function call")
+
+        # Extract function name
+        func_name_to_patch = self.extract_func_name(func_call)
+
+        # Extract arguments and keyword arguments directly from the func_call node
+        args = [ast.Str(s=func_name_to_patch)]  # Start with the function name as the first argument
+
+        # Add arguments from the function call
+        for arg in func_call.args:
+            args.append(self.transform_arg(arg))
+
+        # Transform keyword arguments if present
+        kwargs = []
+        for kw in func_call.keywords:
+            kwargs.append(ast.keyword(arg=kw.arg, value=self.transform_arg(kw.value)))
+
+        kwargs.append(ast.keyword(arg='expected_output', value=self.transform_arg(expected_output)))
+
+        # Prepare 'expected_output' as a keyword argument
+        expected_output_kwarg = ast.keyword(
+            arg='__expected_output',
+            value=self.transform_arg(expected_output)
+        )
+        align_direction_kwarg = ast.keyword(
+            arg='__align_direction',
+            value=ast.Constant(_align_direction)
+        )
+
+        # Construct the call to dynamic_call
+        dynamic_call = ast.Call(
+            func=ast.Name(id='dynamic_call', ctx=ast.Load()),
+            args=args,
+            keywords=[expected_output_kwarg, align_direction_kwarg]
+        )
+
+        return ast.Expr(value=dynamic_call)

--- a/src/tanuki/static_assertion_visitor.py
+++ b/src/tanuki/static_assertion_visitor.py
@@ -12,7 +12,7 @@ class Or(list):
     pass
 
 
-class AssertionVisitor(ast.NodeVisitor):
+class StaticAssertionVisitor(ast.NodeVisitor):
     def __init__(self,
                  scope: Optional[dict] = None,
                  patch_symbolic_funcs: Dict[str, Callable] = {},

--- a/tests/test_align/test_align_dynamic.py
+++ b/tests/test_align/test_align_dynamic.py
@@ -61,6 +61,11 @@ def list_align_int():
         assert summarise_int(ex[0]) == ex[1]
 
 @tanuki.align
+def list_align_variable(align_list):
+    for ex in align_list:
+        assert summarise_int(ex[0]) == ex[1]
+
+@tanuki.align
 def read_risk_factors():
 
 
@@ -91,6 +96,8 @@ def read_risk_factors():
 
     assert highlight_potential_risks(example2) == output_2
 
+
+list_align_variable([(1, "This is number 1"), (2, "This is number 2")])
 list_align_int()
 read_risk_factors()
 #

--- a/tests/test_align/test_align_dynamic.py
+++ b/tests/test_align/test_align_dynamic.py
@@ -1,0 +1,94 @@
+from typing import List
+
+from dotenv import load_dotenv
+
+import tanuki
+import unittest
+load_dotenv()
+report = """
+        Project Scale: Managing 39-home development in London.
+        Funding Approach: Utilizing internal cash flow.
+        Lead Source: Came through a mutual contact.
+        Previous Work: Handled a major project in Lincoln.
+        Our Relationship: Just starting, but looks promising.
+        Future Business: Client seems keen on continuing with us.
+        Notes: While everything's looking up, we're keeping an eye on balancing the project's ambitious scope with our cash flow strategy and nurturing this new relationship carefully. Excited to see where this partnership goes!
+        """
+
+example_1 = \
+    """
+    Development: Engaged in a large 39-home project in London.
+    Financing: Self-financed, keeping tabs on cash flow.
+    Lead Source: Connection from a friend.
+    Experience: Previous success with a significant Lincoln project.
+    Our Connection: New but promising relationship.
+    Future Plans: The client is positive about ongoing business.
+    """
+
+example_2 = \
+    """
+    Size of the Customer’s Development Project: 21 homes in London, worth about $5m
+    How the Project is Being Financed: Through company cash flow
+    How the Customer Came Across the Project Lead: Via a friend of a friend,
+    Past Projects of the Customer: Large project in Sleaford
+    Relationship Between the Company and Customer/Related Parties: New
+    Future Purchases by the Customer: Optimistic
+    Risk Factors from the Customer:Financial stability concerns, unverified lead sources, and the nascent nature of our relationship.
+    Anything else relevant about the Customer: None
+    Customer’s Expected Purchases and Reasons: 16 tons of bricks
+    """
+
+
+@tanuki.patch
+def highlight_potential_risks(report: str) -> List[str]:
+    """
+    This is a report provided by a sales representative about a customer that is trading with us.
+    Extract any potential risky phrases from the report, especially those that could negatively affect the company's cash flow or likelihood to default on payments.
+    Don't include any line headers.
+    :return:
+    """
+
+@tanuki.align
+def read_risk_factors():
+
+
+    example1 = "\n".join([part.strip() for part in example_1.split("\n")])
+    example2 = "\n".join([part.strip() for part in example_2.split("\n")])
+
+    actual_patched_output = highlight_potential_risks(example1)
+    print(actual_patched_output)
+    output_1 = [
+        "keeping tabs on cash flow",
+        "New"
+    ]
+
+    output_2 = [
+        "Financial stability concerns",
+        "unverified lead sources",
+        "nascent nature of our relationship",
+        "Through company cash flow",
+        "New"
+    ]
+
+    try:
+        assert highlight_potential_risks(example1) == output_1
+    except AssertionError as e:
+        print(f"Expected: {output_1}")
+        print(f"Got: {highlight_potential_risks(example1)}")
+        raise e
+
+    assert highlight_potential_risks(example2) == output_2
+
+read_risk_factors()
+#
+# class TestSMS(unittest.TestCase):
+#
+#     def setUp(self):
+#         pass
+#         #self.indexer = InferenceService()
+#         #self.read_risk_factors()
+#
+#
+#
+# if __name__ == '__main__':
+#     unittest.main()

--- a/tests/test_align/test_align_dynamic.py
+++ b/tests/test_align/test_align_dynamic.py
@@ -48,6 +48,18 @@ def highlight_potential_risks(report: str) -> List[str]:
     :return:
     """
 
+@tanuki.patch
+def summarise_int(input: int) -> str:
+    """
+    Summarise the input
+    """
+
+@tanuki.align
+def list_align_int():
+    align_list = [(1, "This is number 1"), (2, "This is number 2")]
+    for ex in align_list:
+        assert summarise_int(ex[0]) == ex[1]
+
 @tanuki.align
 def read_risk_factors():
 
@@ -79,6 +91,7 @@ def read_risk_factors():
 
     assert highlight_potential_risks(example2) == output_2
 
+list_align_int()
 read_risk_factors()
 #
 # class TestSMS(unittest.TestCase):

--- a/tests/test_assertion_visitor/test_mock.py
+++ b/tests/test_assertion_visitor/test_mock.py
@@ -7,7 +7,7 @@ from typing import Optional, List
 from pydantic import BaseModel
 
 import tanuki
-from tanuki.assertion_visitor import AssertionVisitor, Or
+from tanuki.static_assertion_visitor import StaticAssertionVisitor, Or
 
 
 def _parse(source):
@@ -22,7 +22,7 @@ def _parse(source):
 
     tree = ast.parse(source)
     _locals = locals()
-    visitor = AssertionVisitor(locals(), patch_symbolic_funcs={"create_todolist_item": create_todolist_item})
+    visitor = StaticAssertionVisitor(locals(), patch_symbolic_funcs={"create_todolist_item": create_todolist_item})
     visitor.visit(tree)
     return visitor.mocks
 

--- a/tests/test_assertion_visitor/test_pydantic_constraints.py
+++ b/tests/test_assertion_visitor/test_pydantic_constraints.py
@@ -7,14 +7,14 @@ from typing import Optional, List
 from pydantic import BaseModel, Field
 
 import tanuki
-from tanuki.assertion_visitor import AssertionVisitor, Or
+from tanuki.static_assertion_visitor import StaticAssertionVisitor, Or
 
 
 def _parse(source, func):
     tree = ast.parse(source)
     _locals = locals()
 
-    visitor = AssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": func})
+    visitor = StaticAssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": func})
     visitor.visit(tree)
     return visitor.mocks
 
@@ -36,7 +36,7 @@ assert analyze_article(html_content, "nvidia") == ArticleSummary(
     tree = ast.parse(source)
     _locals = locals()
 
-    visitor = AssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": analyze_article})
+    visitor = StaticAssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": analyze_article})
     visitor.visit(tree)
 
     mocks = visitor.mocks
@@ -61,7 +61,7 @@ assert analyze_article(html_content, "nvidia") == ArticleSummary(
     tree = ast.parse(source)
     _locals = locals()
 
-    visitor = AssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": analyze_article})
+    visitor = StaticAssertionVisitor(locals(), patch_symbolic_funcs={"analyze_article": analyze_article})
     visitor.visit(tree)
 
     mocks = visitor.mocks

--- a/tests/test_patch/test_classification.py
+++ b/tests/test_patch/test_classification.py
@@ -21,8 +21,8 @@ def classify_sentiment(input: str) -> Optional[Literal['Good', 'Bad']]:
     Determine if the input is positive or negative sentiment
     """
 
-@tanuki.align
-def align_classify_sentiment():
+@tanuki.runtime_align
+def test_align_classify_sentiment():
     """We can test the function as normal using Pytest or Unittest"""
 
     i_love_you = "I love you"
@@ -30,13 +30,11 @@ def align_classify_sentiment():
     assert classify_sentiment_2("I hate you", "You're discusting") == 'Bad'
     assert classify_sentiment_2("Today is wednesday", "The dogs are running outside") == None
 
-
     assert classify_sentiment("I love you") == 'Good'
     assert classify_sentiment("I hate you") == 'Bad'
     assert classify_sentiment("Wednesdays are in the middle of the week") == None
 
 def test_classify_sentiment():
-    align_classify_sentiment()
     bad_input = "I find you awful"
     good_input = "I really really like you"
     good_input_2 = "I adore you"
@@ -47,3 +45,5 @@ def test_classify_sentiment():
     assert classify_sentiment_2(good_input, good_input_2) == 'Good'
     assert classify_sentiment_2("I do not like you you", bad_input) == 'Bad'
     assert classify_sentiment_2("I am neutral", "I am neutral too") == None
+
+test_align_classify_sentiment()


### PR DESCRIPTION
Instead of statically analysing assert statements, we now replace them with a function that is invoked at runtime to capture the behaviour.

This allows us to assert over data loaded in - useful if we have datasets that we want to use to initially define the expected behaviour of a patched function. 

This also now allows us to perform asserts over live data - to selectively determine whether a result is good enough to make it into the distillation database.