### PR TITLE
Suppressing UserWarning for pydantic

### DIFF
--- a/src/tanuki/language_models/llm_configs/abc_base_config.py
+++ b/src/tanuki/language_models/llm_configs/abc_base_config.py
@@ -1,6 +1,8 @@
 import abc 
 from pydantic import BaseModel#, ConfigDict
 from typing import Optional
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning)
 
 class BaseModelConfig(abc.ABC, BaseModel):
     """


### PR DESCRIPTION
Suppressing userwarnings because of pydantic having a protected namespace with model_. We can't use ConfigDict because that isn't compatible with lower pydantic versions